### PR TITLE
KA-365 - Add additional nested document action "merge" attempts to merge based on the child id before adding

### DIFF
--- a/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateDocumentMerger.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateDocumentMerger.java
@@ -170,6 +170,10 @@ public class AtomicUpdateDocumentMerger {
         .filter(doc -> doc.containsKey("id"))
         .collect(Collectors.toMap(doc -> doc.get("id").getValue().toString(), doc -> doc));
 
+    if(existingField.getValues().size() != originalItemsById.size()) {
+      throw new SolrException(ErrorCode.INVALID_STATE, "Merge can not be called on field: " + existingField.getName() + " since it contains values which are either not SolrInputDocument's or do not have an id property");
+    }
+
     Object toBeAdded = getNativeFieldValue(name, fieldVal);
 
     if (toBeAdded instanceof Collection) {
@@ -193,7 +197,7 @@ public class AtomicUpdateDocumentMerger {
       }
       toDoc.setField(name, originalItemsById.values());
     } else {
-      throw new SolrException(ErrorCode.BAD_REQUEST, "Invalid update: " + toBeAdded + "should be a SolrInputDocument");
+      throw new SolrException(ErrorCode.BAD_REQUEST, "Invalid merge: " + toBeAdded + " should be a SolrInputDocument");
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateProcessorFactory.java
+++ b/solr/core/src/java/org/apache/solr/update/processor/AtomicUpdateProcessorFactory.java
@@ -60,7 +60,8 @@ public class AtomicUpdateProcessorFactory extends UpdateRequestProcessorFactory 
   private final static String SET = "set";
   private final static String REMOVEREGEX = "removeregex";
   private final static String ADDDISTINCT = "add-distinct";
-  private final static Set<String> VALID_OPS = new HashSet<>(Arrays.asList(ADD, INC, REMOVE, SET, REMOVEREGEX, ADDDISTINCT));
+  private final static String MERGE = "merge";
+  private final static Set<String> VALID_OPS = new HashSet<>(Arrays.asList(ADD, INC, REMOVE, SET, REMOVEREGEX, ADDDISTINCT, MERGE));
 
   private final static String VERSION = "_version_";
   public static final String NAME = "atomic";

--- a/solr/core/src/test/org/apache/solr/update/processor/NestedAtomicUpdateTest.java
+++ b/solr/core/src/test/org/apache/solr/update/processor/NestedAtomicUpdateTest.java
@@ -21,7 +21,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -70,6 +72,77 @@ public class NestedAtomicUpdateTest extends SolrTestCaseJ4 {
     assertDocContainsSubset(addedDoc, dummyBlock);
     assertDocContainsSubset(newChildDoc, (SolrInputDocument) ((List) dummyBlock.getFieldValues("child")).get(1));
     assertEquals(dummyBlock.getFieldValue("id"), dummyBlock.getFieldValue("id"));
+  }
+
+  @Test
+  public void testMergeChildDocsWithSameId() throws Exception {
+    SolrInputDocument existingChild = sdoc("id", "2", "cat_ss", "child");
+    SolrInputDocument existingDoc = sdoc("id", "1",
+        "cat_ss", new ArrayList<>(Arrays.asList("aaa", "ccc")),
+        "_root_", "1", "child", new ArrayList<>(sdocs(existingChild)));
+
+    SolrInputDocument updatedChildDoc = sdoc("id", "2", "cat_ss", "updated child");
+    SolrInputDocument updateDoc = sdoc("id", "1",
+        "cat_ss", Collections.singletonMap("add", "bbb"), // add value to collection on parent
+        "child", Collections.singletonMap("merge", sdocs(updatedChildDoc))); // child with same id and updated "cat_ss" field
+
+
+    SolrInputDocument preMergeDoc = new SolrInputDocument(existingDoc);
+    AtomicUpdateDocumentMerger docMerger = new AtomicUpdateDocumentMerger(req());
+    docMerger.merge(updateDoc, existingDoc);
+    assertEquals("merged document should have the same id", preMergeDoc.getFieldValue("id"), existingDoc.getFieldValue("id"));
+    assertDocContainsSubset(preMergeDoc, existingDoc);
+    assertDocContainsSubset(updateDoc, existingDoc);
+    assertEquals(1, existingDoc.getFieldValues("child").size());
+    assertDocContainsSubset(updatedChildDoc, ((SolrInputDocument) existingDoc.getFieldValues("child").toArray()[0]));
+  }
+
+  @Test
+  public void testMergeChildDocsWithSameAndNestedSet() throws Exception {
+    SolrInputDocument existingChild = sdoc("id", "2", "cat_ss", "child");
+    SolrInputDocument existingDoc = sdoc("id", "1",
+        "cat_ss", new ArrayList<>(Arrays.asList("aaa", "ccc")),
+        "_root_", "1", "child", new ArrayList<>(sdocs(existingChild)));
+
+
+    SolrInputDocument updatedChildDoc = sdoc("id", "2", "cat_ss", Collections.singletonMap("set", "updated child"));
+    SolrInputDocument updateDoc = sdoc("id", "1",
+        "cat_ss", Collections.singletonMap("add", "bbb"), // add value to collection on parent
+        "child", Collections.singletonMap("merge", sdocs(updatedChildDoc))); // child with same id and nested set on "cat_ss" field
+
+
+    SolrInputDocument preMergeDoc = new SolrInputDocument(existingDoc);
+    AtomicUpdateDocumentMerger docMerger = new AtomicUpdateDocumentMerger(req());
+    docMerger.merge(updateDoc, existingDoc);
+    assertEquals("merged document should have the same id", preMergeDoc.getFieldValue("id"), existingDoc.getFieldValue("id"));
+    assertDocContainsSubset(preMergeDoc, existingDoc);
+    assertDocContainsSubset(updateDoc, existingDoc);
+    assertEquals(1, existingDoc.getFieldValues("child").size());
+    assertDocContainsSubset(sdoc("id", "2", "cat_ss", "updated child"), ((SolrInputDocument) existingDoc.getFieldValues("child").toArray()[0]));
+  }
+
+  @Test
+  public void testMergeChildDocsWithMultipleChildDocs() throws Exception {
+    SolrInputDocument existingChild = sdoc("id", "2", "cat_ss", "child");
+    SolrInputDocument nonMatchingExistingChild = sdoc("id", "3", "cat_ss", "other");
+    SolrInputDocument existingDoc = sdoc("id", "1",
+        "cat_ss", new ArrayList<>(Arrays.asList("aaa", "ccc")),
+        "_root_", "1", "child", new ArrayList<>(sdocs(existingChild, nonMatchingExistingChild)));
+
+    SolrInputDocument updatedChildDoc = sdoc("id", "2", "cat_ss", "updated child");
+    SolrInputDocument updateDoc = sdoc("id", "1",
+        "cat_ss", Collections.singletonMap("add", "bbb"), // add value to collection on parent
+        "child", Collections.singletonMap("merge", sdocs(updatedChildDoc))); // child with same id and updated "cat_ss" field
+
+
+    SolrInputDocument preMergeDoc = new SolrInputDocument(existingDoc);
+    AtomicUpdateDocumentMerger docMerger = new AtomicUpdateDocumentMerger(req());
+    docMerger.merge(updateDoc, existingDoc);
+    assertEquals("merged document should have the same id", preMergeDoc.getFieldValue("id"), existingDoc.getFieldValue("id"));
+    assertDocContainsSubset(preMergeDoc, existingDoc);
+    assertDocContainsSubset(updateDoc, existingDoc);
+    assertEquals(2, existingDoc.getFieldValues("child").size());
+    assertDocContainsSubset(updatedChildDoc, ((SolrInputDocument) existingDoc.getFieldValues("child").toArray()[0]));
   }
 
   @Test

--- a/solr/solr-ref-guide/src/updating-parts-of-documents.adoc
+++ b/solr/solr-ref-guide/src/updating-parts-of-documents.adoc
@@ -43,6 +43,10 @@ Adds the specified values to a multiValued field. May be specified as a single v
 `add-distinct`::
 Adds the specified values to a multiValued field, only if not already present. May be specified as a single value, or as a list.
 
+`merge`::
+Adds the specified values to a multiValued field, only if not already present based on a matching id check. If present the
+specified value is merged with the existing field value. May be specified as a single value, or as a list.
+
 `remove`::
 Removes (all occurrences of) the specified values from a multiValued field. May be specified as a single value, or as a list.
 


### PR DESCRIPTION
# Description

Solr behaviour is inconsistent when atomically adding nested documents. If a nested document it's added twice (via calling the "add" atomic update operation), it will be added a second time with the same id instead of replacing the previous one. 

Solr has an additional "set" option which overwrites the existing nested document but it doesn't do so selectively but rather replaces all the existing nested docs with those passed.

# Solution

This PR adds an additional atomic update behaviour, "merge",  which adds the specified values to a multiValued field, only if not already present based on a matching id check. If present the specified value is merged with the existing field value.

# Tests

Unit tests in NestedAtomicUpdateTest.java and manual testing with a version of solr built with these changes.

# Checklist

TBC

Please review the following and check all that apply:

- [ ] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [ ] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [ ] I have developed this patch against the `master` branch.
- [ ] I have run `ant precommit` and the appropriate test suite.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Ref Guide](https://github.com/apache/lucene-solr/tree/master/solr/solr-ref-guide) (for Solr changes only).
